### PR TITLE
Changed order of analyzed and raw in the exercise

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -445,7 +445,7 @@ quotes.txt
 >
 > ~~~
 > $ ls -F
-> raw/ analyzed/
+>  analyzed/ raw/
 > $ ls -F analyzed
 > fructose.dat glucose.dat maltose.dat sucrose.dat
 > $ cd raw/


### PR DESCRIPTION
The output of `ls -F` should be in alphabetical order

This was pointed out by a learner during a workshop
